### PR TITLE
have simultaneous requests coming in and have tested how its handled …

### DIFF
--- a/client.rb
+++ b/client.rb
@@ -3,10 +3,28 @@ require 'socket'
 hostname = 'localhost'
 port = 2000
 
-s = TCPSocket.open(hostname, port)
+start_time = Time.now
 
-while line = s.gets
-  puts line.chop
+$stdout.sync = true
+
+threads = []
+
+100.times do
+  threads << Thread.start() do
+    s = TCPSocket.open(hostname, port)
+
+    while line = s.gets
+      puts line.chop
+    end
+
+    s.close
+  end
 end
 
-s.close
+threads.each do |thr|
+  thr.join
+end
+
+end_time = Time.now
+
+puts end_time - start_time

--- a/server.rb
+++ b/server.rb
@@ -10,27 +10,35 @@ def single_client_server
 
   loop do
     client = server.accept
-    client.puts Time.now.ctime
+    sleep 0.1 ##simulates laged db hit
+    #client.puts Time.now.ctime
     client.puts "Closing the connection. Bye!"
     client.close
   end
 end
 
 #single_client_server
+#runs in about 10 seconds, as mathematically expected (100 * .1secs)
 
 def multi_client_server
   server = TCPServer.open(PORT)
+
+  #puts server.methods
 
   loop do
     # This differs from the example above in that a new thread is spawned for each client-to-server
     # connection so that multiple clients can interact with the serverr - a new process per client.
 
-    Thread.start(server.accept) do |client| 
-      client.puts Time.now.ctime
+    Thread.start(server.accept) do |client|
+      sleep 0.1 ##simulates laged database hit
+      #client.puts Time.now.ctime
       client.puts "Closing the connection. Bye!"
       client.close
     end
   end
 end
 
-#multi_client_server
+multi_client_server
+#runs in about .5secs, because the requests are handled each on a single thread.
+#because they are run on their own thread, the "db hit" allows the MRI to
+#move back onto other Threads and fulfilling their requests.


### PR DESCRIPTION
…for both singly and multi threaded servers. Obvi the multithreaded version handles the requests overall quicker, and the singly-threaded runs them one after another (after completion on each)

PS
Not totally sure what you are going for, so I just played around with it and made the client into a simple stress tester for the server (to see how the two versions perform differently).
